### PR TITLE
Remove "'none'" value for merged directives with multiple declarations

### DIFF
--- a/packages/csp-header/src/index.ts
+++ b/packages/csp-header/src/index.ts
@@ -2,6 +2,9 @@ import {
 	ALLOWED_DIRECTIVES,
 } from './constants/directives';
 import {
+	NONE
+} from './constants/values';
+import {
 	CSPHeaderParams,
 	CSPDirectives,
 	CSPDirectiveName,
@@ -133,10 +136,18 @@ function mergeDirectiveRules(directiveValue1: CSPDirectiveValue, directiveValue2
 	}
 
 	if (Array.isArray(directiveValue1) && Array.isArray(directiveValue2)) {
-		return getUniqRules([
+		const uniqRules =  getUniqRules([
 			...directiveValue1,
 			...directiveValue2
 		]);
+
+		const noneIndex = uniqRules.indexOf(NONE);
+		// Remove "'none'" if there are other rules
+		if(noneIndex >= 0 && uniqRules.length > 1) {
+			uniqRules.splice(noneIndex, 1);
+		}
+
+		return uniqRules;
 	}
 
 	return directiveValue2;

--- a/packages/csp-header/tests/index.test.ts
+++ b/packages/csp-header/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { getCSP, CSPDirectiveName, CSPHeaderParams, nonce, SELF } from '../src';
+import {CSPDirectiveName, CSPHeaderParams, getCSP, nonce, NONE, SELF} from '../src';
 
 describe('CSP building', () => {
 	test('should correctly make policy with the only rule', () => {
@@ -107,6 +107,32 @@ describe('Presets', () => {
 			})).toBe('script-src domain1.com domain2.com;')
 		});
 
+		test('should remove \'none\' directive when merging with well-defined directive', () => {
+			expect(getCSP({
+				directives: {
+					'script-src': [ 'domain1.com' ]
+				},
+				presets: [
+					{
+						'script-src': [ NONE ]
+					}
+				]
+			})).toBe('script-src domain1.com;')
+		});
+
+		test('should remove \'none\' directive when merging with well-defined preset', () => {
+			expect(getCSP({
+				directives: {
+					'script-src': [ NONE ]
+				},
+				presets: [
+					{
+						'script-src': [ 'domain2.com' ]
+					}
+				]
+			})).toBe('script-src domain2.com;')
+		});
+
 		test('should work with empty policies', () => {
 			expect(getCSP({
 				directives: {},
@@ -204,6 +230,32 @@ describe('Presets', () => {
 					}
 				}
 			})).toBe('script-src domain1.com domain2.com;')
+		});
+
+		test('should remove \'none\' directive when merging with well-defined directive', () => {
+			expect(getCSP({
+				directives: {
+					'script-src': [ 'domain1.com' ]
+				},
+				presets: {
+					myPreset: {
+						'script-src': [ NONE ]
+					}
+				}
+			})).toBe('script-src domain1.com;')
+		});
+
+		test('should remove \'none\' directive when merging with well-defined preset', () => {
+			expect(getCSP({
+				directives: {
+					'script-src': [ NONE ]
+				},
+				presets: {
+					myPreset: {
+						'script-src': [ 'domain2.com' ]
+					}
+				}
+			})).toBe('script-src domain2.com;')
 		});
 
 		test('should work with empty policies', () => {


### PR DESCRIPTION
The "'none'" value is used to indicate that no resources are allowed. If the "'none'" value is used in combination with other resources, it should be ignored as defined by https://w3c.github.io/webappsec-csp/#match-url-to-source-list Some browsers however, warn on this behaviour. It is therefor best to remove the "'none'" value in this instance.

Fixes #5