### PR TITLE
chore(express-csp-header): upgrade psl dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3404,11 +3404,10 @@
       "license": "MIT"
     },
     "node_modules/@types/psl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/psl/-/psl-1.1.0.tgz",
-      "integrity": "sha512-HhZnoLAvI2koev3czVPzBNRYvdrzJGLjQbWZhqFmS9Q6a0yumc5qtfSahBGb5g+6qWvA8iiQktqGkwoIXa/BNQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/psl/-/psl-1.1.3.tgz",
+      "integrity": "sha512-Iu174JHfLd7i/XkXY6VDrqSlPvTDQOtQI7wNAXKKOAADJ9TduRLkNdMgjGiMxSttUIZnomv81JAbAbC0DhggxA==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.16",
@@ -7557,16 +7556,17 @@
       "license": "MIT"
     },
     "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "license": "MIT"
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.10.0.tgz",
+      "integrity": "sha512-KSKHEbjAnpUuAUserOq0FxGXCUrzC3WniuSJhvdbs102rL55266ZcHBqLWOsG30spQMlPdpy7icATiAQehg/iA==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8574,11 +8574,11 @@
       "license": "WTFPL",
       "dependencies": {
         "csp-header": "^6.0.0",
-        "psl": "1.8.0"
+        "psl": "1.10.0"
       },
       "devDependencies": {
         "@types/express": "4.17.11",
-        "@types/psl": "1.1.0"
+        "@types/psl": "1.1.3"
       },
       "engines": {
         "node": ">=18"

--- a/packages/express-csp-header/package.json
+++ b/packages/express-csp-header/package.json
@@ -29,10 +29,10 @@
   "homepage": "https://github.com/frux/csp/tree/master/packages/express-csp-header#readme",
   "devDependencies": {
     "@types/express": "4.17.11",
-    "@types/psl": "1.1.0"
+    "@types/psl": "1.1.3"
   },
   "dependencies": {
     "csp-header": "^6.0.0",
-    "psl": "1.8.0"
+    "psl": "1.10.0"
   }
 }


### PR DESCRIPTION
Using this library with node 22 throws a DeprecationWarning

```
nzr: [app] (node:91403) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
nzr: [app]     at node:punycode:3:9
nzr: [app]     at BuiltinModule.compileForInternalLoader (node:internal/bootstrap/realm:399:7)
nzr: [app]     at BuiltinModule.compileForPublicLoader (node:internal/bootstrap/realm:338:10)
nzr: [app]     at loadBuiltinModule (node:internal/modules/helpers:114:7)
nzr: [app]     at Function._load (node:internal/modules/cjs/loader:1100:17)
nzr: [app]     at TracingChannel.traceSync (node:diagnostics_channel:315:14)
nzr: [app]     at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
nzr: [app]     at Module.require (node:internal/modules/cjs/loader:1340:12)
nzr: [app]     at require (node:internal/modules/helpers:141:16)
nzr: [app]     at Object.<anonymous> (/Users/user/src/repo/node_modules/express-csp-header/node_modules/psl/index.js:5:16)
```

This is the commit that fixed the issue in `psl` - https://github.com/lupomontero/psl/commit/3ddec00372501a4657d28fbd87e6fd59db12a897
